### PR TITLE
TST: update ruff and codespell versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: python -m build
     - name: Publish Python package to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-    # Docuemntation
+    # Documentation
     - name: Install doc dependencies
       run: |
         pip install -r requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/sphinx_apipages/__init__.py
+++ b/sphinx_apipages/__init__.py
@@ -10,6 +10,7 @@ and builds the documentation afterwards,
 ignoting all files inside ``apipages_src_dir``.
 
 """
+
 import filecmp
 import os
 import shutil


### PR DESCRIPTION
Update `ruff` and `codespell` pre-commits to the versions we now use in other packages.

## Summary by Sourcery

Update the versions of ruff and codespell pre-commit hooks to align with other packages.

Build:
- Update ruff pre-commit hook to version 0.7.0.
- Update codespell pre-commit hook to version 2.3.0.